### PR TITLE
save twice with GetOrCreateNestedSerializerMixin

### DIFF
--- a/hello/serializers.py
+++ b/hello/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from drf_writable_nested import WritableNestedModelSerializer
+from drf_writable_nested.mixins import GetOrCreateNestedSerializerMixin
 
 from .models import Avatar, Site, AccessKey, Profile, User
 
@@ -12,7 +13,9 @@ class AvatarSerializer(serializers.ModelSerializer):
         fields = ('pk', 'image',)
 
 
-class SiteSerializer(serializers.ModelSerializer):
+class SiteSerializer(serializers.ModelSerializer,
+                     GetOrCreateNestedSerializerMixin):
+    DEFAULT_MATCH_ON = ['url',]
     url = serializers.CharField()
 
     class Meta:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@ django==2.2
 gunicorn==19.9.0
 django-heroku==0.3.1
 djangorestframework==3.9.2
-drf-writable-nested==0.5.1
+# patched
+# drf-writable-nested==0.5.1
+https://github.com/claytondaley/drf-writable-nested/zipball/cf0c9441950f77c6680afb4ef681e583a5e92036/


### PR DESCRIPTION
I thought GetOrCreateNestedSerializerMixin would only match if the request was nested, but this test seems to show it matches even if SiteSerializer is called in a non-nested manner.

```
FAIL: test_save_site_twice (hello.tests.SerializerTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dan/work/appcensus/drf-writable-example/hello/tests.py", line 100, in test_save_site_twice
    self.assertEqual(2, Site.objects.filter(url=url).count())
AssertionError: 2 != 1
```